### PR TITLE
Fixed xcache/zc install and changed DB_PASS back to MYSQL_PASS

### DIFF
--- a/conf.d/main
+++ b/conf.d/main
@@ -24,6 +24,7 @@ chown -R www-data:www-data $WEBROOT/images
 chown -R www-data:www-data $WEBROOT/admin/backups
 chown -R www-data:www-data $WEBROOT/admin/images/graphs
 chown -R www-data:www-data $WEBROOT/includes/languages/english/html_includes
+chown -R www-data:www-data $WEBROOT/logs
 
 mv $WEBROOT/includes/dist-configure.php $WEBROOT/includes/configure.php 
 mv $WEBROOT/admin/includes/dist-configure.php $WEBROOT/admin/includes/configure.php 
@@ -45,11 +46,14 @@ a2enmod rewrite
 /etc/init.d/apache2 start
 
 # setup the database
-MYSQL_BATCH="mysql --user=root --password=$DB_PASS --batch"
-MYSQL_ADMIN="mysqladmin --user=root --password=$DB_PASS"
+MYSQL_BATCH="mysql --user=root --password=$MYSQL_PASS --batch"
+MYSQL_ADMIN="mysqladmin --user=root --password=$MYSQL_PASS"
 
 $MYSQL_ADMIN create $DB_NAME
 $MYSQL_BATCH --execute "grant all privileges on $DB_NAME.* to $DB_USER@localhost identified by '$DB_PASS'; flush privileges;"
+
+# fix xcache/zc install issue
+sed -i "s|@xcache_clear_cache();|{@ini_set('xcache.cacher', 'OFF');}|" $WEBROOT/zc_install/index.php
 
 # curl based install
 EMAIL=$(echo $ADMIN_MAIL | sed s/@/%40/)


### PR DESCRIPTION
First of all, welcome to the dev team, it's good to have you on board.

Now as per @JedMeister (Jeremy)'s request I had a quick look to see if I could figure this problem out. The only issue I could find apart from the issue that Jeremy resolved was the MYSQL_PASS had been changed to DB_PASS so let me quickly explain how this works (For a full understanding it might be worth reading the TKLDev Docs). Basically each appliance is built over another. Zencart is built over LAMP which is built over Core and each of these "Layers" has their own conf.d scripts and inithooks. It's also worth mentioning that common (https://github.com/turnkeylinux/common) includes all the code that is shared between appliances. So for a LAMP appliance, the makefile includes LAMP which then runs common/conf/mysql (https://github.com/turnkeylinux/common/blob/master/conf/mysql) which will either set the mysql password to MYSQL_PASS or call the inithook to set the MYSQL_PASS. As a general rule you shouldn't ever need to change MYSQL_PASS.

Other than that minor misunderstanding the appliance seems to build fine!

Unrelated to the actual code I did notice a commit by "root" and that your main changes were made in the "master" branch. The auther can be changed by using:

git config --global user.name "YourGithubUsername"
git config --global user.email "YourEmail"

You can also amend the most recent unpushed-commit using:

git commit --amend --reset-author

As for the development in "master" branch you might want to take a look at https://github.com/turnkeylinux/tracker/blob/master/GITFLOW.rst which outlines the standard turnkey gitflow (although you'll notice I too used master after forking from you which was unintentional it is generally regarded good practice to create a new branch before making changes)
